### PR TITLE
fix/Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,28 @@
 # Builder stage
-FROM python:3.11.6-slim AS builder
+FROM python:3.11-slim AS builder
 
-## COPY project files
 ADD app /fastapi/app
 ADD models /fastapi/models
 ADD pyproject.toml pdm.lock README.md /fastapi/
 
 WORKDIR /fastapi
 
-## Install dependencies
 RUN pip install -U pip setuptools wheel && \
     pip install pdm && \
     mkdir __pypackages__ && \
     pdm sync --prod --no-editable
 
 # Runner stage
-FROM python:3.11.6-slim AS runner
+FROM python:3.11-slim AS runner
 
-ENV PYTHONPATH=/fastapi/pkgs
-COPY --from=builder /fastapi/__pypackages__/3.11/lib /fastapi/pkgs
-COPY --from=builder /fastapi/__pypackages__/3.11/bin/* /bin/
+ENV PYTHONPATH=/usr/local/lib/python/
+COPY --from=builder /fastapi/__pypackages__/3.11/lib /usr/local/lib/python/
+COPY --from=builder /fastapi/__pypackages__/3.11/bin/* /usr/local/bin/
 COPY --from=builder /fastapi/app /fastapi/app
 COPY --from=builder /fastapi/models /fastapi/models
 
-ENTRYPOINT ["uvicorn", "--app-dir", "fastapi/app/", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+WORKDIR /fastapi/
+
+ENTRYPOINT ["uvicorn", "--app-dir", "./app/", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
 EXPOSE 8000

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: setup debug docker-image docker-image-arm64 docker-image-amd64 docker-run
+
 arch_flag := $(shell uname -m)
 
 setup:
@@ -6,20 +8,21 @@ setup:
 debug:
 	@uvicorn --app-dir app/ main:app --host 0.0.0.0 --port 8000 --reload
 
-docker-image:
-	@docker buildx build -t iobruno/fastapi-model-serve:latest-aarch64 . --platform linux/arm64
-	@docker buildx build -t iobruno/fastapi-model-serve:latest-amd64 . --platform linux/amd64
+docker-image: docker-image-arm64 docker-image-amd64 
+
+docker-image-arm64:
+	@docker buildx build -t iobruno/fastapi-model-serve:aarch64 . --platform linux/arm64
+
+docker-image-amd64:
+	@docker buildx build -t iobruno/fastapi-model-serve:amd64 . --platform linux/amd64
 
 docker-run:
 ifeq (${arch_flag},arm64)
-	@docker run -p 8000:8000/tcp -e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python iobruno/fastapi-model-serve:latest-aarch64
+	@docker run -p 8000:8000 -e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python iobruno/fastapi-model-serve:aarch64
 endif
 ifeq (${arch_flag},aarch64)
-	@docker run -p 8000:8000/tcp -e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python iobruno/fastapi-model-serve:latest-aarch64
+	@docker run -p 8000:8000 -e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python iobruno/fastapi-model-serve:aarch64
 endif
 ifeq (${arch_flag},x86_64)
-	@docker run -p 8000:8000/tcp -e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python iobruno/fastapi-model-serve:latest-amd64
+	@docker run -p 8000:8000 -e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python iobruno/fastapi-model-serve:amd64
 endif
-
-
-.PHONY: setup debug docker-image docker-run


### PR DESCRIPTION
## Summary

* Changes base image to `python:3.11-slim`

* Update PYTHONPATH on Runner image to `/usr/local/lib/python`, 
   while having the binaries in `/usr/local/bin/`

* Add 'WORKDIR' on Runner image, so updates the ENTRYPOINT accordingly

* Add Makefile tasks to build specifically for 'arm64' or 'amd64'