### PR TITLE
chore/refactor: refactors Makefile and code clean up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,51 @@
-.PHONY: setup debug docker-image docker-image-arm64 docker-image-amd64 docker-run
+.PHONY: run docker-image docker-run
 
 arch_flag := $(shell uname -m)
 
-setup:
-	@pdm sync --no-self
+IMG_NAME_ARM64 := iobruno/fastapi-tf-serve:aarch64
+IMG_NAME_AMD64 := iobruno/fastapi-tf-serve:amd64
 
-debug:
+run:
 	@uvicorn --app-dir app/ main:app --host 0.0.0.0 --port 8000 --reload
 
-docker-image: docker-image-arm64 docker-image-amd64 
-
 docker-image-arm64:
-	@docker buildx build -t iobruno/fastapi-tf-serve:aarch64 . --platform linux/arm64 --no-cache
+	@docker buildx build -t $(IMG_NAME_ARM64) . --platform linux/arm64 --no-cache
 
 docker-image-amd64:
-	@docker buildx build -t iobruno/fastapi-tf-serve:amd64 . --platform linux/amd64 --no-cache
+	@docker buildx build -t $(IMG_NAME_AMD64) . --platform linux/amd64 --no-cache
+
+docker-image:
+ifeq (${arch_flag},arm64)
+	@$(MAKE) docker-image-arm64
+endif
+ifeq (${arch_flag},aarch64)
+	@$(MAKE) docker-image-arm64
+endif
+ifeq (${arch_flag},x86_64)
+	@$(MAKE) docker-image-amd64
+endif
+
+docker-run-arm64:
+	@docker run --rm \
+		-e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python \
+		-p 8000:8000 \
+		--name fastapi-tf-serve \
+		$(IMG_NAME_ARM64)
+
+docker-run-amd64:
+	@docker run --rm \
+		-e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python \
+		-p 8000:8000 \
+		--name fastapi-tf-serve \
+		$(IMG_NAME_ARM64)
 
 docker-run:
 ifeq (${arch_flag},arm64)
-	@docker run --rm \
-		-e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python \
-		-p 8000:8000 \
-		--name fastapi-tf-serve \
-		iobruno/fastapi-tf-serve:aarch64
+	@$(MAKE) docker-run-arm64
 endif
 ifeq (${arch_flag},aarch64)
-	@docker run --rm \
-		-e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python \
-		-p 8000:8000 \
-		--name fastapi-tf-serve \
-		iobruno/fastapi-tf-serve:aarch64
+	@$(MAKE) docker-run-arm64
 endif
 ifeq (${arch_flag},x86_64)
-	@docker run --rm \
-		-e PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python \
-		-p 8000:8000 \
-		--name fastapi-tf-serve \
-		iobruno/fastapi-tf-serve:amd64
+	@$(MAKE) docker-run-amd64
 endif

--- a/README.md
+++ b/README.md
@@ -20,21 +20,50 @@ GitHub project for Tensorflow-based Object Detection on the CIFAR-10 dataset, se
 
 ## Up and Running
 
-**Building a Docker Image**:
+### Developer Setup 
+
+**1.** Create and activate a virtualenv with conda:
+```shell
+conda create -n tfserve python=3.11 -y
+conda activate tfserve
+```
+
+**2.** Install the dependencies on `pyproject.toml`:
+```shell
+pdm sync --no-self
+```
+
+**3.** Start the app with `gunicorn` with:
+```shell
+uvicorn --app-dir app/ main:app --host 0.0.0.0 --port 8000 --reload
+```
+or simply execute:
+```
+make run
+```
+
+**4.** Access the Swagger UI at:
+```
+open http://localhost:8000
+```
+
+## Containerization and Testing
+
+**1.** Build the Docker Image with:
+
 ```shell
 make docker-image
 ```
 
-**Running on Docker**:
+**2.** Spin up the container with:
 ```shell
 make docker-run
 ```
 
-**Local Development**:
-```shell
-make setup
+**3.** Access the Swagger UI at:
 ```
-
+open http://localhost:8000
+```
 
 ## TODO
 - [x] PEP-517: Packaging and dependency management with PDM

--- a/app/classifier/cifar10.py
+++ b/app/classifier/cifar10.py
@@ -1,10 +1,11 @@
-import httpx as r
 from io import BytesIO
-from PIL import Image
-
-from tensorflow.keras.utils import img_to_array
-from tensorflow.keras.models import load_model
 from pathlib import Path
+
+import httpx as r
+import numpy as np
+from PIL import Image
+from tensorflow.keras.models import load_model
+from tensorflow.keras.utils import img_to_array
 
 models_dir = Path(__file__).parent.parent.parent.joinpath("models")
 model = load_model(models_dir.joinpath("cifar10_model_v2.h5"))
@@ -26,13 +27,14 @@ labels = [
 def predict(image_url: str):
     response = r.get(image_url)
     img = Image.open(BytesIO(response.content)).convert("RGB").resize((32, 32))
-    img_array = img_to_array(img)
-    arr = img_array[None, ...]
-    return model.predict(arr)
+    img_arr_3d: np.array = img_to_array(img)
+    img_arr_4d: np.array = img_arr_3d[None, ...]
+    predictions: np.array = model.predict(img_arr_4d).flatten()
+    return format(predictions)
 
 
-def fmt_predictions(arr):
+def format(predictions: np.array) -> dict:
     return {
-        labels[idx]: round(float(prediction) * 100, 5)
-        for idx, prediction in enumerate(arr)
+        labels[index]: round(float(prediction) * 100, 5)
+        for index, prediction in enumerate(predictions)
     }

--- a/app/classifier/cifar10.py
+++ b/app/classifier/cifar10.py
@@ -24,7 +24,7 @@ labels = [
 ]
 
 
-def predict(image_url: str):
+def predict(image_url: str) -> dict:
     response = r.get(image_url)
     img = Image.open(BytesIO(response.content)).convert("RGB").resize((32, 32))
     img_arr_3d: np.array = img_to_array(img)

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.responses import RedirectResponse
 from routers import predict
-import uvicorn
+from starlette.responses import RedirectResponse
 
 app = FastAPI()
 app.include_router(predict.router)

--- a/app/routers/predict.py
+++ b/app/routers/predict.py
@@ -5,5 +5,5 @@ router = APIRouter()
 
 
 @router.get("/predict/cifar10")
-async def classify_image(url: str):
+async def classify_image(url: str) -> dict:
     return predict(url)

--- a/app/routers/predict.py
+++ b/app/routers/predict.py
@@ -1,10 +1,9 @@
+from classifier.cifar10 import predict
 from fastapi import APIRouter
-from classifier.cifar10 import predict, fmt_predictions
 
 router = APIRouter()
 
 
 @router.get("/predict/cifar10")
 async def classify_image(url: str):
-    predictions = predict(url).flatten()
-    return fmt_predictions(predictions)
+    return predict(url)


### PR DESCRIPTION
## Summary

* Refactors Makefile:
  * `make docker-image` now builds for the current architecture only
  * `make docker-run` spins up a container for the respective arch
  * Drops the task `setup`
* Minor refactor on project files to clean up
* Adds type hints on cifar10 classifier
* Reformats the project files, and fixes import orders
* Updates running instructions on README
